### PR TITLE
Add gcloud & update to 22.04

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,5 +1,5 @@
 # This container must be run in privileged mode, as the fuse mount for cvmfs does not work otherwise.
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED 1
@@ -10,15 +10,27 @@ ENV AWS_ENDPOINT=https://s3-ap-southeast-2.amazonaws.com
 ENV AWS_REGION=ap-southeast-2
 
 RUN set -xe; \
-    apt-get -qq update && apt-get install -y --no-install-recommends \
+    apt-get -qq update && \
+    apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | tee /usr/share/keyrings/cloud.google.gpg && \
+    apt-get -qq update && \
+    apt-get install -y --no-install-recommends \
         ansible \
         autofs \
-        gnupg \
+        google-cloud-sdk \
         jq \
-        s3cmd \
         rsync \
-    && apt-get autoremove -y && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/*
+        s3cmd \
+        s3fs \
+        wget && \
+    apt-get autoremove -y && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* && \
+    mkdir /opt/s3fs
 
 # Set working directory to /app/
 WORKDIR /app/
@@ -29,11 +41,5 @@ RUN ansible-galaxy install -r cvmfs-client-requirements.yaml -p roles && \
     # remove the autofs validation lines as we don't have /dev/fuse mounted at build time
     sed -i.bak -e '18,22d;26,27d' ./roles/galaxyproject.cvmfs/tasks/client.yml && \
     ansible-playbook -i cvmfs-client-hosts.ini cvmfs-client-playbook.yaml
-
-# We need at least s3fs 1.90 for env var based access keys to work
-RUN wget https://media.githubusercontent.com/media/maresb/docker-build-s3fs/master/builds/s3fs_1.91+git-v1.91-3_amd64.deb && \
-    dpkg -i s3fs_1.91+git-v1.91-3_amd64.deb && \
-    rm s3fs_1.91+git-v1.91-3_amd64.deb && \
-    mkdir /opt/s3fs
 
 CMD /app/sync.sh

--- a/.github/docker/cvmfs-client-requirements.yaml
+++ b/.github/docker/cvmfs-client-requirements.yaml
@@ -1,2 +1,2 @@
 - src: galaxyproject.cvmfs
-  version: 0.2.14
+  version: 0.2.18


### PR DESCRIPTION
Gcloud is needed for the tools cloning repo. An image built from this file is available as `galaxy/cvmfs-client:latest`.